### PR TITLE
Fix double quote escaping

### DIFF
--- a/Resources/config/assetic.yml
+++ b/Resources/config/assetic.yml
@@ -3,7 +3,7 @@ assetic:
     filters:
         cssrewrite: ~
         lessphp:
-            apply_to: "\.less$"
+            apply_to: '\.less$'
             formatter: "compressed"
             preserve_comments: false
     bundles:


### PR DESCRIPTION
Newer Symfony versions will complain about the YAML file being invalid